### PR TITLE
changing to `canShare()`

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -7,7 +7,7 @@
 {% block header %}
   {{super()}}
   <script>
-    if (navigator.share) { 
+    if (navigator.canShare()) { 
         let btn = document.createElement("button");
         btn.innerHTML = '{% include ".icons/material/share-variant.svg" %}';
         btn.classList.add("md-header__button", "md-icon","twemoji");


### PR DESCRIPTION
`Navigator.canShare()`

Returns true if a call to Navigator.share() would succeed.

Reference: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/canShare