### PR TITLE
Added a custom share popup for unsupported devices

### DIFF
--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -129,3 +129,64 @@ li:has(.md-nav__link--active) label
   src: url("./fonts/roboto_mono_latin_400.woff2") format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
+/* CUSTOM CSS FOR SWAL ALERT */
+svg {
+    width: 20px;
+    height: 20px;
+    margin-right: 7px;
+}
+
+.copy-link, .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: auto;
+    padding-top: 8px;
+    padding-bottom: 8px;
+    color: #777;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.1;
+    letter-spacing: 2px;
+    text-transform: capitalize;
+    text-decoration: none;
+    white-space: nowrap;
+    border-radius: 4px;
+    border: 1px solid #ddd;
+    cursor: pointer;
+}
+
+.copy-link:hover, .button:hover {
+    border-color: #cdd;
+}
+
+.copy-link {
+    padding-left: 30px;
+    padding-right: 30px;
+}
+
+.targets {
+    display: grid;
+    grid-template-rows: 1fr 1fr;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 20px;
+    margin-bottom: 20px;
+}
+
+.link {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 10px;
+    border-radius: 4px;
+    background-color: #eee;
+}
+
+.pen-url {
+    margin-right: 15px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,24 +2,89 @@
 
 {% block extrahead %}
 <link rel="manifest" href="{{ 'manifest.json' | url }}">
+<script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 {% endblock %}
 
 {% block header %}
   {{super()}}
   <script>
-    if (navigator.share) { 
-        let btn = document.createElement("button");
-        btn.innerHTML = '{% include ".icons/material/share-variant.svg" %}';
-        btn.classList.add("md-header__button", "md-icon","twemoji");
-        var title = document.getElementsByClassName("md-header__inner")[0];
-        title.insertBefore(btn, document.getElementsByClassName("md-header__option")[0]);
+    function selectText(nodeId) {
+        const node = document.getElementById(nodeId);
 
-        btn.addEventListener('click', event => {
-            navigator.share({
-                title: document.title,
-                url: window.location.href
-            });
-        });
+        if (document.body.createTextRange) {
+            const range = document.body.createTextRange();
+            range.moveToElementText(node);
+            range.select();
+        } else if (window.getSelection) {
+            const selection = window.getSelection();
+            const range = document.createRange();
+            range.selectNodeContents(node);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        } else {
+            console.warn("Could not select text in node: Unsupported browser.");
+        }
     }
+
+    let btn = document.createElement("button");
+    btn.innerHTML = '{% include ".icons/material/share-variant.svg" %}';
+    btn.classList.add("md-header__button", "md-icon","twemoji");
+    var title = document.getElementsByClassName("md-header__inner")[0];
+    title.insertBefore(btn, document.getElementsByClassName("md-header__option")[0]);
+
+    btn.addEventListener('click', event => {
+        var title = document.title;
+        var url = window.location.href;
+
+        if (navigator.share) { 
+          navigator.share({
+              title: title,
+              url: url
+          });
+        }
+        else{
+          Swal.fire({
+            title: 'Share '+title,
+            html:
+              `<div class="targets">
+                <a class="button" href="https://www.facebook.com/sharer.php?u=`+url+`">
+                  <span class="twemoji">
+                    {% include ".icons/material/facebook.svg" %} 
+                  </span>
+                  <span>Facebook</span>
+                </a>
+                
+                <a class="button" href="https://twitter.com/intent/tweet?url=`+url+`">
+                  <span class="twemoji">
+                    {% include ".icons/material/twitter.svg" %} 
+                  </span>
+                  <span>Twitter</span>
+                </a>
+                
+                <a class="button" href="https://www.linkedin.com/sharing/share-offsite/?url=`+url+`">
+                  <span class="twemoji">
+                    {% include ".icons/material/linkedin.svg" %} 
+                  </span>
+                  <span>LinkedIn</span>
+                </a>
+                
+                <a class="button" href="mailto:?body=`+url+`">
+                  <span class="twemoji">
+                    {% include ".icons/material/email.svg" %} 
+                  </span>
+                  <span>Email</span>
+                </a>
+              </div>
+              <div class="link">
+                <div class="pen-url" id="urltext">`+url+`</div>
+                <button class="copy-link" onclick="navigator.clipboard.writeText('`+url+`');selectText('urltext')">Copy Link</button>
+              </div>
+            </div>
+            `,
+            showCloseButton: true,
+            showConfirmButton: false
+          });
+        } 
+    });
   </script>
 {% endblock %}


### PR DESCRIPTION
This will show a custom popup for devices that do not support the WebShare API as discussed in #30 

Code Overview:
To make the popup work I am importing the SWAL js module, [SweetAlert](https://sweetalert2.github.io/) is fetched via a cdn, and it allows for clean, responsive popups.

Possible Minor Issue(s):

- Might clash with theme, as popup always has white bg.
- Might be slightly slower due to added script import (not necessarily)