### PR TITLE
CI Changes: Single Commit Deployment, updated to latest git-committers-plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,5 @@ jobs:
       - uses: actions/setup-python@v3
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
-      - run: pip install mkdocs-minify-plugin
-      - run: pip install mkdocs-jupyter
-      - run: pip install mkdocs-git-committers-plugin-2
-      - run: pip install mkdocs-git-revision-date-localized-plugin
-      - run: pip install lxml
+      - run: pip install -r requirements.txt
       - run: mkdocs gh-deploy --force --no-history

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      MKDOCS_GIT_COMMITTERS_APIKEY: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,4 @@ jobs:
       - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install lxml
-      - run: mkdocs gh-deploy --force
-      - run: git checkout gh-pages
-      - run: git reset --hard HEAD~1
-      - run: git push --force origin gh-pages 
+      - run: mkdocs gh-deploy --force --no-history

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,6 @@ jobs:
       - run: pip install git+https://github.com/ojacques/mkdocs-git-committers-plugin-2@60b1a7c --user
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install lxml
+      - run: git push --delete origin gh-pages
+        continue-on-error: true
       - run: mkdocs gh-deploy --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - run: pip install mkdocs-material
       - run: pip install mkdocs-minify-plugin
       - run: pip install mkdocs-jupyter
-      - run: pip install git+https://github.com/ojacques/mkdocs-git-committers-plugin-2@60b1a7c --user
+      - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install lxml
       - run: git push --delete origin gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: pip install mkdocs-git-committers-plugin-2
       - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: pip install lxml
-      - run: git push --delete origin gh-pages
-        continue-on-error: true
       - run: mkdocs gh-deploy --force
+      - run: git checkout gh-pages
+      - run: git reset --hard HEAD~1
+      - run: git push --force origin gh-pages 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs-material
 mkdocs-minify-plugin
 mkdocs-jupyter
-git+https://github.com/ojacques/mkdocs-git-committers-plugin-2@60b1a7c
+mkdocs-git-committers-plugin-2
 lxml
 mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
Part of #78 

And a general workflow update - reduced lines, updated to latest version of a plugin. [Preview](https://fir121.github.io/uni-notes/)
